### PR TITLE
Updated to be more idiomatic Vue

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5313,12 +5313,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -5333,17 +5335,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -5460,7 +5465,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -5472,6 +5478,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -5486,6 +5493,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -5493,12 +5501,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -5517,6 +5527,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -5597,7 +5608,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -5609,6 +5621,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -5730,6 +5743,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",

--- a/src/ToDo.vue
+++ b/src/ToDo.vue
@@ -5,16 +5,10 @@
       <h1 class="ToDo-Header">Vue To Do</h1>
       <div class="ToDo-Container">
         <div class="ToDo-Content">
-
-          <ToDoItem v-for="item in this.list"
-                    :todo="item.todo"
-                    :key="list.indexOf(item)"
-                    :id="list.indexOf(item)"
-          >
-          </ToDoItem>
-
-
-
+          <ToDoItem v-for="todo in list" 
+                    :todo="todo" 
+                    @delete="onDeleteItem"
+                    :key="todo.id" />
         </div>
         <input type="text" v-model="todo" v-on:keyup.enter="createNewToDoItem"/>
         <div class="ToDo-Add" @click="createNewToDoItem()">+</div>
@@ -36,10 +30,12 @@ export default {
       return {
           list: [
               {
-                  'todo': 'clean the house'
+                id: 1,
+                text: 'clean the house'
               },
               {
-                  'todo': 'buy milk'
+                id: 2,
+                text: 'buy milk'
               }
           ],
           todo: '',
@@ -48,24 +44,23 @@ export default {
   },
 
   methods: {
-
-      //still need to add thing here to stop this from triggering if the input field is empty. likely needs event paremeter passed to function
       createNewToDoItem() {
-          this.list.push(
-              {
-                  'todo': this.todo
-              }
-          );
-          this.todo = '';
+        //validate todo
+        if (!this.todo){
+          alert("Please enter a todo!")
+          return
+        }
+
+        const newId = Math.max.apply(null, this.list.map(t => t.id)) + 1
+        this.list.push({ id: newId, text: this.todo});
+        this.todo = '';
+      },
+      onDeleteItem(todo){
+        console.log("called", todo)
+        this.list = this.list.filter(item => item !== todo)
       }
 
   },
-
-  mounted() {
-    this.$on('delete', (event) => {
-        this.list = this.list.filter(item => item.todo !== event)
-    })
-  }
 }
 </script>
 

--- a/src/components/ToDoItem.vue
+++ b/src/components/ToDoItem.vue
@@ -1,6 +1,6 @@
 <template>
-    <div class="ToDoItem" :id="id">
-        <p class="ToDoItem-Text">{{todo}}</p>
+    <div class="ToDoItem">
+        <p class="ToDoItem-Text">{{todo.text}}</p>
         <div class="ToDoItem-Delete" @click="deleteItem(todo)">-</div>
     </div>
 </template>
@@ -8,12 +8,10 @@
 <script>
     export default {
         name: "to-do-item",
-        props: [
-            'id', 'todo'
-        ],
+        props: ['todo'],
         methods: {
             deleteItem(todo) {
-                this.$parent.$emit('delete', todo)
+                this.$emit('delete', todo)
             }
         }
     }


### PR DESCRIPTION
The main change is to remove manually listening to the delete event emitted by the ToDoItem.vue component. In vue, you generally to not want to reach out of a component using $parent because it creates a dependency between the child and parent component. Instead, just emit the event from the child component and listen to it in the parent (what the code was doing was actually emitting the event from the parent).

I also added an "id" property to the todo items. Using an index as a key for components is not generally a good idea because the list can mutate. Best practice is to use an "id" property of the list you are iterating.